### PR TITLE
oncokb: Add OncoKB API client

### DIFF
--- a/missense_kinase_toolkit/databases/mkt/databases/api_schema.py
+++ b/missense_kinase_toolkit/databases/mkt/databases/api_schema.py
@@ -77,3 +77,29 @@ class APIKeySwaggerClient(SwaggerAPIClient, ABC):
 class RESTAPIClient(APIClient, ABC):
     @abstractmethod
     def query_api(self): ...
+
+
+class APIKeyRESTAPIClient(RESTAPIClient, ABC):
+    @abstractmethod
+    def maybe_get_token(self) -> str | None:
+        """Get API token, if available.
+
+        Returns
+        -------
+        str | None
+            API token if available; None otherwise
+
+        """
+        ...
+
+    def set_api_key(self) -> dict:
+        """Set API token for REST API.
+
+        Returns
+        -------
+        dict
+            Dictionary with API token set
+
+        """
+        token = self.maybe_get_token()
+        return {"Authorization": f"Bearer {token}"} if token else {}

--- a/missense_kinase_toolkit/databases/mkt/databases/config.py
+++ b/missense_kinase_toolkit/databases/mkt/databases/config.py
@@ -11,6 +11,8 @@ CBIOPORTAL_TOKEN_VAR = "CBIOPORTAL_TOKEN"
 REQUESTS_CACHE_VAR = "REQUESTS_CACHE"
 """str: Environment variable for request cache file prefix; \
     if none provided, default is requests_cache in CLI scripts"""
+ONCOKB_TOKEN_VAR = "ONCOKB_TOKEN"
+"""str: Environment variable for OncoKB token; if none provided, default is `None` in CLI scripts"""
 
 
 def set_output_dir(val: str) -> None:
@@ -136,5 +138,35 @@ def maybe_get_request_cache() -> str | None:
     """
     try:
         return os.environ[REQUESTS_CACHE_VAR]
+    except KeyError:
+        return None
+
+
+def set_oncokb_token(val: str) -> None:
+    """Set the OncoKB token in the environment variables.
+
+    Parameters
+    ----------
+    val : str
+        OncoKB token
+
+    Returns
+    -------
+    None
+
+    """
+    os.environ[ONCOKB_TOKEN_VAR] = val
+
+
+def maybe_get_oncokb_token() -> str | None:
+    """Get the OncoKB token from the environment.
+
+    Returns
+    -------
+    str | None
+        OncoKB token as string if exists, otherwise None
+    """
+    try:
+        return os.environ[ONCOKB_TOKEN_VAR]
     except KeyError:
         return None

--- a/missense_kinase_toolkit/databases/mkt/databases/oncokb.py
+++ b/missense_kinase_toolkit/databases/mkt/databases/oncokb.py
@@ -1,0 +1,198 @@
+import logging
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+
+from mkt.databases import requests_wrapper
+from mkt.databases.api_schema import APIKeyRESTAPIClient
+from mkt.databases.config import maybe_get_oncokb_token
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class OncoKB(APIKeyRESTAPIClient, ABC):
+    """OncoKB API client."""
+
+    url: str = "https://www.oncokb.org/api/v1"
+    """Base URL for the OncoKB API."""
+    header: dict = field(default_factory=dict)
+    """OncoKB API token, if available."""
+    url_query: str | None = field(init=False, default=None)
+    """URL to update for specific queries."""
+    _json: dict | None = field(init=False, default=None)
+
+    def __post_init__(self):
+        """Initialize the OncoKB API client."""
+        self.header = self.set_api_key()
+        try:
+            "Authorization" in self.header
+            self.header.update({"Accept": "application/json"})
+        except KeyError:
+            logger.error(
+                "No OncoKB API token provided. Please set it in the environment."
+            )
+        self.update_url()
+        self.query_api()
+
+    def maybe_get_token(self) -> str | None:
+        return maybe_get_oncokb_token()
+
+    @abstractmethod
+    def update_url(self): ...
+
+    def query_api(self):
+        """Query the OncoKB API for a given URL."""
+        res = requests_wrapper.get_cached_session().get(
+            self.url_query, headers=self.header
+        )
+        if res.ok:
+            self._json = res.json()
+        else:
+            logger.error(f"Error querying OncoKB API: {res.status_code} - {res.text}")
+            self._json = None
+
+    def has_json(self) -> dict | None:
+        """Get the JSON response from the OncoKB API query.
+
+        Returns
+        -------
+        dict | None
+            JSON response if available, otherwise None
+
+        """
+        if self._json is None:
+            logger.error("No data available. Please query the API first or fix query.")
+            return False
+        return True
+
+    @staticmethod
+    def extract_level_as_int(str_in: str | None) -> int | None:
+        """Extract the level from a string and convert it to an integer.
+
+        Parameters
+        ----------
+        str_in : str | None
+            String containing the level information
+
+        Returns
+        -------
+        int | None
+            Level as integer if found, otherwise None
+
+        """
+        import re
+
+        if str_in is None:
+            return None
+        try:
+            return int(re.search(r"\d+", str_in).group())
+        except (ValueError, IndexError):
+            logger.error(f"Could not extract level from string: {str_in}")
+            return None
+
+
+@dataclass
+class OncoKBProteinChange(OncoKB):
+    """OncoKB API client for protein changes."""
+
+    gene_name: str | None = None
+    """Gene associated with the protein change."""
+    alteration: str | None = None
+    """Alteration type (e.g., V600E if BRAF is gene)."""
+    dict_highest_level: dict[str, int] = field(
+        default_factory=lambda: {
+            "Sensitive": None,
+            "Resistance": None,
+            "Diagnostic_Implication": None,
+            "Prognostic_Implication": None,
+            "FDA": None,
+        }
+    )
+    """Dictionary to store the highest level of evidence for each alteration."""
+    list_treatment: list[str] = field(default_factory=list)
+    """List of treatments associated with the alteration."""
+    oncogenic: str | None = None
+    """Oncogenic status of the alteration."""
+    vus: bool | None = None
+    """Whether the alteration is a Variant of Uncertain Significance (VUS)."""
+    known_effect: str | None = None
+    """Effect of the mutation on the protein (e.g., missense, nonsense)."""
+    verbose: bool = True
+    """Whether to log warnings for missing data."""
+
+    def __post_init__(self):
+        """Initialize the OncoKBProteinChange client."""
+        if self.gene_name is None or self.alteration is None:
+            logger.error("Gene name and alteration must be provided.")
+        else:
+            super().__post_init__()
+            if self.has_json():
+                if self._json["geneExist"] and self._json["variantExist"]:
+                    self.annotate_highest_level()
+                    self.get_treatments()
+                    self.oncogenic = self._json.get("oncogenic", None)
+                    self.vus = self._json.get("vus", None)
+                    if "mutationEffect" in self._json:
+                        self.known_effect = self._json["mutationEffect"].get(
+                            "knownEffect", None
+                        )
+                elif self._json["geneExist"]:
+                    logger.error(
+                        f"Alteration {self.alteration} does not exist for gene {self.gene_name} in OncoKB."
+                    )
+                elif self._json["variantExist"]:
+                    logger.error(
+                        f"Gene {self.gene_name} does not exist in OncoKB for alteration {self.alteration}."
+                    )
+                else:
+                    logger.error(
+                        f"Gene {self.gene_name} and alteration {self.alteration} does not exist in OncoKB."
+                    )
+
+    def update_url(self):
+        """Update the URL for the OncoKB API query based on the UniProt ID."""
+        if self.gene_name is None or self.alteration is None:
+            logger.error("Gene name and alteration must be provided.")
+        else:
+            self.url_query = (
+                f"{self.url}/annotate/mutations/byProteinChange"
+                f"?hugoSymbol={self.gene_name}&alteration={self.alteration}"
+            )
+
+    def annotate_highest_level(self):
+        """Annotate the highest level of evidence for the protein change."""
+        for key in self.dict_highest_level.keys():
+            key_orig = (
+                "highest" + "".join([i.title() for i in key.split("_")]) + "Level"
+            )
+            if key_orig in self._json:
+                level = self.extract_level_as_int(self._json[key_orig])
+                if level is not None:
+                    self.dict_highest_level[key] = level
+            else:
+                if self.verbose:
+                    logger.warning(
+                        f"No '{key_orig}' found in response for "
+                        f"{self.gene_names}_{self.alteration}."
+                    )
+
+    def get_treatments(self):
+        """Get the list of treatments associated with the alteration."""
+        if "treatments" in self._json:
+            try:
+                self.list_treatment = [
+                    [j["drugName"] for j in i["drugs"]]
+                    for i in self._json["treatments"]
+                ]
+            except Exception as e:
+                if self.verbose:
+                    logger.error(
+                        f"Error extracting treatments for "
+                        f"{self.gene_name}_{self.alteration}: {e}"
+                    )
+        else:
+            if self.verbose:
+                logger.warning(
+                    f"No 'treatments' found in response for "
+                    f"{self.gene_name}_{self.alteration}."
+                )


### PR DESCRIPTION
## Description
Allow for OncoKB API queries.

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [x] Allow for OncoKB token use in config
  - [x] Support API key in RESTAPIClient in API schema
  - [x] Query Annotate Mutations by Protein Change in API

## Questions
- [ ] Are there any other API queries we need to support (e.g., SV annotation)?

## Status
- [x] Ready to go
