### PR TITLE
chore: gitignore stray KinCore CIF extraction directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -207,3 +207,7 @@ configs/
 data/3d_hotspots.xls
 data/tumor_types.txt
 data/AF2_Active_Models_v2.zip
+
+# stray KinCore CIFs from a legacy disk-extract; the pipeline reads the v2 zip
+# in memory (extract_pk_cif_files_as_list), so these are never shipped as package data
+missense_kinase_toolkit/databases/mkt/databases/KinCore/


### PR DESCRIPTION
## Description

Ignore the stray `missense_kinase_toolkit/databases/mkt/databases/KinCore/` directory. Those
437 `.cif` files were once shipped as individual package data (commit `59dad65`); Phase 3 moved
KinCore CIF handling to reading the `AF2_Active_Models_v2.zip` **in memory**
(`extract_pk_cif_files_as_list` via `zf.read()` + `io.StringIO`), so the files were dropped from
tracking — but an on-disk copy lingered locally. This adds a `.gitignore` guard so a legacy
disk-extract can never be re-committed as package data.

Standalone hygiene fix off `main` (kept out of the `databases` PR to avoid re-triggering its CI).

## Todos
- [x] `.gitignore` rule for the package `KinCore/` directory
- [x] Confirm no current code writes it (both `extract_pk_cif_files_as_list` and
  `update_original_cif_with_new_coords` read in memory)

## Questions
- [ ] None

## Status
- [x] Ready to go

🤖 Generated with [Claude Code](https://claude.com/claude-code)
